### PR TITLE
Revise Travis build to install EVM without travis-evm-cask.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,17 @@ sudo: false
 
 env:
   - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.3-travis
 
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
-  - evm install $EVM_EMACS --use --skip
+  - export PATH="$HOME/.evm/bin:$HOME/.cask/bin:$PATH"
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - evm config path /tmp
+  - evm install $EVM_EMACS --use
+  - export EMACS=$(which emacs)
+  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+
+install:
   - cask install
 
 script:


### PR DESCRIPTION
from https://gist.github.com/rejeep/ebcd57c3af83b049833b.

* Upgrade emacs matrix to use 25.3.
* Specify EMACS environment variable to force Cask use it